### PR TITLE
switch from tail to native --console_log

### DIFF
--- a/services/couchpotato/run
+++ b/services/couchpotato/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 umask 0002
-exec /sbin/setuser abc python /app/couchpotato/CouchPotato.py --config_file=/config/config.ini --data_dir=/config/data
+exec /sbin/setuser abc python /app/couchpotato/CouchPotato.py --config_file=/config/config.ini --data_dir=/config/data --console_log

--- a/services/tail-error/run
+++ b/services/tail-error/run
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec /sbin/setuser abc tail -F /config/data/logs/error.log

--- a/services/tail/run
+++ b/services/tail/run
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec /sbin/setuser abc tail -F /config/data/logs/CouchPotato.log


### PR DESCRIPTION
It's there at the end of `services/couchpotato/run`.