### PR TITLE
Update CouchPotatoServer git repo url.

### DIFF
--- a/init/30_update.sh
+++ b/init/30_update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-[[ ! -d /app/couchpotato/.git ]] && /sbin/setuser abc git clone https://github.com/RuudBurger/CouchPotatoServer.git /app/couchpotato
+[[ ! -d /app/couchpotato/.git ]] && /sbin/setuser abc git clone https://github.com/CouchPotato/CouchPotatoServer.git /app/couchpotato
 
 # opt out for autoupdates
 [ "$ADVANCED_DISABLEUPDATES" ] && exit 0

--- a/init/30_update.sh
+++ b/init/30_update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-[[ ! -d /app/couchpotato/.git ]] && /sbin/setuser abc git clone https://github.com/CouchPotato/CouchPotatoServer.git /app/couchpotato
+[[ ! -d /app/couchpotato/.git ]] && /sbin/setuser abc git clone git@github.com:CouchPotato/CouchPotatoServer.git /app/couchpotato
 
 # opt out for autoupdates
 [ "$ADVANCED_DISABLEUPDATES" ] && exit 0


### PR DESCRIPTION
Apparently the couchpotato git repo moved, the new one is under CouchPotato/CouchPotatoServer, without this the container won't pull at all (fatal: Could not read from remote repository.).